### PR TITLE
Bugfix: utter_hallo eingebaut

### DIFF
--- a/data/nlu/responses/responses_main.yml
+++ b/data/nlu/responses/responses_main.yml
@@ -47,3 +47,6 @@ responses:
         - Drogen: {drogenabhaengig}
         - Volljährig: {volljaehrig}
         - Unter 22 (jugendlich): {jugendlich}
+  
+  utter_hallo: 
+    - text: "Hallo, ich bin Lise. Wie kann ich dir weiterhelfen?"


### PR DESCRIPTION
Damit der Bot funktioniert, wurde `utter_hallo` mit in die Responses aufgenommen. Das sollte den Bug beheben, dass der Bot die entsprechende utterance nicht findet.